### PR TITLE
fix client side only component

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,20 +1,17 @@
 exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
-  if (stage === "build-html") {
-    actions.setWebpackConfig({
-      module: {
-        rules: [
-          {
-            test: /scrollmagic/,
-            use: loaders.null(),
-          },
-          {
-            test: /ScrollMagic/,
-            use: loaders.null(),
-          },
-        ],
-      },
-    })
-  }
+  // Custom loader is no longer needed because we dynamically load the Magic.js component with react-loadable
+  // if (stage === "build-html") {
+  //   actions.setWebpackConfig({
+  //     module: {
+  //       rules: [
+  //         {
+  //           test: /Magic.js/,
+  //           use: loaders.raw(),
+  //         },
+  //       ],
+  //     },
+  //   })
+  // }
 }
 
 exports.onCreateNode = args => {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
+    "@loadable/component": "^5.12.0",
     "@svgr/webpack": "^5.0.1",
     "babel-plugin-styled-components": "^1.10.6",
     "gatsby": "^2.18.12",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,9 @@
 import React from "react"
+import Loadable from "@loadable/component"
 import Block from "../components/Block"
-import Magic from "../components/Magic"
 import "../styles/global.css"
+// React loadable will only load the magic component in the browser because this component doesn't work on the server (dependent on the window)
+const Magic = Loadable(() => import("../components/Magic"))
 
 export default () => {
   return (


### PR DESCRIPTION
Your code was failing because the Magic.js component couldn't load window on the server.

You tried to avoid this by giving it a loader.null() webpack loader, but this caused the Magic component to return nothing which isn't a valid component.

Easy fix is to use react loadable to only load this component on the client side.

As an aside, your webpack regex was too broad and was also loading svg's and css files as null.

Hope this helps! 